### PR TITLE
Utf8

### DIFF
--- a/battinfo_app/BattInfo_converter.py
+++ b/battinfo_app/BattInfo_converter.py
@@ -110,7 +110,7 @@ def main() -> None:
                     + "  \n".join(["- " + w for w in warnings])
                 )
 
-            jsonld_str = json.dumps(jsonld_output, indent=4, use_decimal=True)
+            jsonld_str = json.dumps(jsonld_output, indent=4, use_decimal=True, ensure_ascii=False)
 
             # Download button
             to_download = BytesIO(jsonld_str.encode())

--- a/battinfo_app/pages/2_Download_Excel_templates.py
+++ b/battinfo_app/pages/2_Download_Excel_templates.py
@@ -15,7 +15,7 @@ from battinfoconverter_backend.templates.template_conversion import (
 @st.cache_data
 def get_xlsx_bytes(schema_path: Path, *, empty: bool) -> tuple[bytes, str]:
     """Create xlsx bytes object, and get version."""
-    with schema_path.open("r") as f:
+    with schema_path.open("r", encoding="utf-8") as f:
         data = json.load(f)
     version = next(
         (

--- a/src/battinfoconverter_backend/validate.py
+++ b/src/battinfoconverter_backend/validate.py
@@ -21,7 +21,7 @@ def get_context() -> dict:
         return _MAPPED_TERMS
     _MAPPED_TERMS = {}
     for file in CONTEXT_DIR.glob("*.json"):
-        with file.open("r") as f:
+        with file.open("r", encoding="utf-8") as f:
             data = json.load(f)
         _MAPPED_TERMS.update(data)
     return _MAPPED_TERMS

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -53,14 +53,14 @@ class CellFixtures:
     def jsonld(self) -> dict:
         """Get path to expected JSON-LD output."""
         path = JSONLD_PATHS[self._param]
-        with path.open("r") as f:
+        with path.open("r", encoding="utf-8") as f:
             return json.load(f)
 
     @cached_property
     def template(self) -> dict:
         """Get path to JSON template."""
         path = TEMPLATE_PATHS[self._param]
-        with path.open("r") as f:
+        with path.open("r", encoding="utf-8") as f:
             return json.load(f)
 
 

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -5,6 +5,7 @@ import json
 import pytest
 from conftest import CellFixtures, normalize_jsonld
 from pyld import jsonld
+from openpyxl import load_workbook
 
 from battinfoconverter_backend.json_convert import convert_excel_to_jsonld
 from battinfoconverter_backend.templates.template_conversion import (
@@ -40,13 +41,26 @@ def test_no_warnings(schema: CellFixtures, caplog: pytest.LogCaptureFixture) -> 
     assert caplog.text == ""
 
 
-def test_round_trip(schema: CellFixtures) -> None:
-    """The template should survive roundtrips to excel and JSON."""
+def test_round_trip_from_json(schema: CellFixtures) -> None:
+    """The template should survive roundtrip starting from JSON template."""
     data1 = schema.template
     wb1 = dict_to_workbook(data1)
     data2 = workbook_to_dict(wb1)
     wb2 = dict_to_workbook(data2)
     data3 = workbook_to_dict(wb2)
+    assert data1 == data2
+    assert data2 == data3
+
+
+def test_round_trip_from_excel(schema: CellFixtures) -> None:
+    """The template should survive roundtrip starting from Excel test file."""
+    wb1 = load_workbook(schema.excel)
+    data1 = workbook_to_dict(wb1)
+    wb2 = dict_to_workbook(data1)
+    data2 = workbook_to_dict(wb2)
+
+    data3 = schema.template  # must also match the template
+
     assert data1 == data2
     assert data2 == data3
 


### PR DESCRIPTION
Easy to get garbled special characters going between JSON, excel, etc. as encoding is switched between utf-8, windows-1252, and ASCII

This PR ensures utf-8 is used consistently, and symbols like µ or ° are preserved properly.

More thorough tests are added to ensure that round-trip conversion starting from both JSON-template and excel-template survive without changes.