### PR TITLE
Fix missing ref electrode type in half cell

### DIFF
--- a/src/battinfoconverter_backend/json_convert.py
+++ b/src/battinfoconverter_backend/json_convert.py
@@ -11,8 +11,8 @@ from openpyxl import Workbook
 from . import auxiliary as aux
 from .excel_tools import ExcelContainer
 from .json_template import (
-    rated_cap_vs_graphite,
-    rated_cap_vs_li,
+    half_cell_chg_cap,
+    half_cell_dchg_cap,
 )
 from .registry import Registry
 from .validate import validate_jsonld
@@ -164,7 +164,8 @@ def reformat_json_rated_capacity(json_dict: dict) -> dict:
     try:
         # Positive electrode
         sub_dict = json_dict["hasPositiveElectrode"]["hasMeasuredProperty"][0]["@reverse"]["hasOutput"]["hasInput"]
-        json_dict["hasPositiveElectrode"]["hasMeasuredProperty"][0]["@reverse"]["hasOutput"] = rated_cap_vs_graphite(
+        json_dict["hasPositiveElectrode"]["hasMeasuredProperty"][0]["@reverse"]["hasOutput"] = half_cell_chg_cap(
+            sub_dict["ElectrochemicalHalfCell"]["hasReferenceElectrode"]["@type"][-1],
             sub_dict["ConstantCurrentCharging"]["hasInput"][1]["hasNumericalPart"]["hasNumberValue"],
             sub_dict["ConstantCurrentCharging"]["hasInput"][2]["hasNumericalPart"]["hasNumberValue"],
             sub_dict["ConstantVoltageCharging"]["hasInput"][0]["hasNumericalPart"]["hasNumberValue"],
@@ -174,7 +175,8 @@ def reformat_json_rated_capacity(json_dict: dict) -> dict:
         )
         # Negative electrode
         sub_dict = json_dict["hasNegativeElectrode"]["hasMeasuredProperty"][0]["@reverse"]["hasOutput"]["hasInput"]
-        json_dict["hasNegativeElectrode"]["hasMeasuredProperty"][0]["@reverse"]["hasOutput"] = rated_cap_vs_li(
+        json_dict["hasNegativeElectrode"]["hasMeasuredProperty"][0]["@reverse"]["hasOutput"] = half_cell_dchg_cap(
+            sub_dict["ElectrochemicalHalfCell"]["hasReferenceElectrode"]["@type"][-1],
             sub_dict["ConstantCurrentDischarging"]["hasInput"][1]["hasNumericalPart"]["hasNumberValue"],
             sub_dict["ConstantCurrentDischarging"]["hasInput"][0]["hasNumericalPart"]["hasNumberValue"],
             sub_dict["ConstantVoltageCharging"]["hasInput"][0]["hasNumericalPart"]["hasNumberValue"],

--- a/src/battinfoconverter_backend/json_template.py
+++ b/src/battinfoconverter_backend/json_template.py
@@ -1,7 +1,8 @@
 """Templates for sections that are too complicated for the Excel ontology link."""
 
 
-def rated_cap_vs_graphite(
+def half_cell_chg_cap(
+    ref_electrode_type: str,
     charge_current_density: float,
     upper_voltage_limit: float,
     upper_voltage_hold: float,
@@ -15,7 +16,7 @@ def rated_cap_vs_graphite(
         "hasTestObject": {
             "ElectrochemicalCell": {
                 "@type": "ElectrochemicalCell",
-                "hasNegativeElectrode": {"@type": "Graphite"},
+                "hasReferenceElectrode": {"@type": ref_electrode_type},
             }
         },
         "hasMeasurementParameter": {
@@ -89,7 +90,8 @@ def rated_cap_vs_graphite(
     }
 
 
-def rated_cap_vs_li(
+def half_cell_dchg_cap(
+    ref_electrode_type: str,
     discharge_current_density: float,
     lower_voltage_limit: float,
     lower_voltage_hold: float,
@@ -103,7 +105,7 @@ def rated_cap_vs_li(
         "hasTestObject": {
             "ElectrochemicalHalfCell": {
                 "@type": "ElectrochemicalHalfCell",
-                "hasReferenceElectrode": {"@type": "LithiumElectrode"},
+                "hasReferenceElectrode": {"@type": ref_electrode_type},
             }
         },
         "hasMeasurementParameter": {

--- a/test/data/coincell_jsonld_result.json
+++ b/test/data/coincell_jsonld_result.json
@@ -150,8 +150,8 @@
                         "hasTestObject": {
                             "ElectrochemicalCell": {
                                 "@type": "ElectrochemicalCell",
-                                "hasNegativeElectrode": {
-                                    "@type": "Graphite"
+                                "hasReferenceElectrode": {
+                                    "@type": "Lithium"
                                 }
                             }
                         },
@@ -381,7 +381,7 @@
                             "ElectrochemicalHalfCell": {
                                 "@type": "ElectrochemicalHalfCell",
                                 "hasReferenceElectrode": {
-                                    "@type": "LithiumElectrode"
+                                    "@type": "Lithium"
                                 }
                             }
                         },


### PR DESCRIPTION
Partially addresses #58 
Now input reference electrode type will be passed forward instead of always being changed to graphite and lithium
Changes both to be half cells with a reference electrode

This is not a full fix, we need to get rid of this json_template entirely. But this at least improves the situation.